### PR TITLE
Fix Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,9 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=ci
+
+
 pull_request_rules:
   - name: Auto Squash and Merge
     conditions:
@@ -6,9 +12,9 @@ pull_request_rules:
       - 'label=ready to squash and merge'
     actions:
       delete_head_branch: {}
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
   - name: Auto Rebase and Merge
     conditions:
       - base=master
@@ -16,6 +22,6 @@ pull_request_rules:
       - 'label=ready to rebase and merge'
     actions:
       delete_head_branch: {}
-      merge:
+      queue:
         method: rebase
-        strict: smart
+        name: default


### PR DESCRIPTION
Following https://github.com/ui-router/sample-app-angular-hybrid/pull/894

Update mergify config to use queues

We can test that this works properly with the Angular 14 update PR: https://github.com/ui-router/sample-app-angular/pull/771 by applying the label `ready to squash and merge` once the PR is approved and CI check's pass in that PR